### PR TITLE
feat: add deploy workflow for MVP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "links/**/*.csv"
+      - "apps/worker/**"
   workflow_dispatch:
 
 jobs:
@@ -13,10 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Parse CSVs and sync to KV
         run: |
@@ -48,4 +58,3 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/worker
-

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@gitly/worker",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "wrangler deploy --dry-run --outdir=dist",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "hono": "^4.0.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240208.0",
+    "typescript": "^5.3.0",
+    "wrangler": "^3.28.0"
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,36 @@
+import { Hono } from 'hono'
+
+type Bindings = {
+  LINKS: KVNamespace
+}
+
+const app = new Hono<{ Bindings: Bindings }>()
+
+// Health check
+app.get('/health', (c) => c.json({ status: 'ok' }))
+
+// Redirect handler
+app.get('/:slug', async (c) => {
+  const slug = c.req.param('slug')
+  
+  // Look up the URL in KV
+  const url = await c.env.LINKS.get(slug)
+  
+  if (!url) {
+    return c.notFound()
+  }
+  
+  // 301 permanent redirect
+  return c.redirect(url, 301)
+})
+
+// Root - could be a landing page later
+app.get('/', (c) => {
+  return c.json({
+    name: 'gitly.sh',
+    description: 'URL shortener for developers',
+    docs: 'https://github.com/andrewmurphyio/gitly.sh'
+  })
+})
+
+export default app

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2021"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "gitly-sh"
+main = "src/index.ts"
+compatibility_date = "2024-02-01"
+
+# Production route
+routes = [
+  { pattern = "gitly.sh", custom_domain = true }
+]
+
+# KV namespace for link storage
+[[kv_namespaces]]
+binding = "LINKS"
+id = "" # Set via GitHub Actions or wrangler cli

--- a/links/andrewmurphyio/links.csv
+++ b/links/andrewmurphyio/links.csv
@@ -1,0 +1,2 @@
+slug,url
+gh,https://github.com/andrewmurphyio

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "gitly.sh",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "turbo run dev",
+    "build": "turbo run build",
+    "deploy": "turbo run deploy"
+  },
+  "devDependencies": {
+    "turbo": "^2.0.0"
+  },
+  "packageManager": "pnpm@9.0.0"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "apps/*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "deploy": {
+      "dependsOn": ["build"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the GitHub Actions deploy workflow for MVP.

### What it does

- Triggers on push to `main` when `links/**/*.csv` files change
- Parses all user CSV files under `links/*/links.csv`
- Syncs slug→URL mappings to Cloudflare KV
- Deploys the Worker via wrangler-action

### Secrets needed

- `CLOUDFLARE_API_TOKEN` — API token with Workers/KV permissions
- `CLOUDFLARE_ACCOUNT_ID` — Your Cloudflare account ID
- `KV_NAMESPACE_ID` — The KV namespace for link storage

### Not included (per MVP scope)

- ~~PR validation workflow~~ — manual review for now
- ~~Analytics export workflow~~ — later

Closes #8