### PR TITLE
Add /dl shortlink for debuggingleadership.com

### DIFF
--- a/links/andrewmurphyio/links.csv
+++ b/links/andrewmurphyio/links.csv
@@ -1,2 +1,3 @@
 slug,url
 gh,https://github.com/andrewmurphyio
+dl,https://debuggingleadership.com


### PR DESCRIPTION
Adds the `/dl` shortlink pointing to https://debuggingleadership.com

Closes #12