### PR TITLE
feat: add dl shortlink for debuggingleadership.com

### DIFF
--- a/links/andrewmurphyio/links.csv
+++ b/links/andrewmurphyio/links.csv
@@ -1,2 +1,3 @@
 slug,url
 gh,https://github.com/andrewmurphyio
+dl,https://debuggingleadership.com


### PR DESCRIPTION
Adds the test link:

- `/dl` → `https://debuggingleadership.com`

Closes #12