### PR TITLE
Add security headers to responses

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,13 @@ type Bindings = {
 
 const app = new Hono<{ Bindings: Bindings }>()
 
+// Security headers middleware
+app.use('*', async (c, next) => {
+  await next()
+  c.header('X-Content-Type-Options', 'nosniff')
+  c.header('X-Frame-Options', 'DENY')
+})
+
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok' }))
 


### PR DESCRIPTION
## Summary

Adds security headers middleware to all responses.

## Changes

- `X-Content-Type-Options: nosniff` - Prevents MIME type sniffing
- `X-Frame-Options: DENY` - Prevents clickjacking via iframes

## Related

Closes #27

---
_From security review (#16)_