### PR TITLE
fix: use 302 redirects instead of 301

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -27,8 +27,9 @@ app.get('/:slug', async (c) => {
     return c.notFound()
   }
   
-  // 301 permanent redirect
-  return c.redirect(url, 301)
+  // 302 temporary redirect - safer for user-generated content
+  // (301s are cached by browsers indefinitely, making malicious link removal ineffective)
+  return c.redirect(url, 302)
 })
 
 // Root - could be a landing page later


### PR DESCRIPTION
## Summary

Changes permanent 301 redirects to temporary 302 redirects for safer handling of user-generated content.

## Why

301 redirects are cached by browsers indefinitely. If a malicious link gets merged and then removed, affected users will **still be redirected** from their browser cache — the removal is ineffective.

302 redirects avoid this issue. The performance impact is minimal for a redirect service (browsers just make the request each time instead of using cache).

## Changes

- `apps/worker/src/index.ts`: Changed redirect from 301 to 302 with explanatory comment

Closes #23