### PR TITLE
fix: substitute KV_NAMESPACE_ID in wrangler.toml before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,5 +42,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/worker
-        env:
-          KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+          preCommands: |
+            sed -i "s/\$KV_NAMESPACE_ID/${{ secrets.KV_NAMESPACE_ID }}/g" wrangler.toml


### PR DESCRIPTION
Wrangler doesn't perform shell-style variable substitution in toml files — `$KV_NAMESPACE_ID` was being sent as a literal string.

Added `preCommands` step to sed-replace the placeholder with the actual secret value before deploy.

Fixes #37