### PR TITLE
fix: sync links to D1 for click tracking analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Sync links to KV
+      - name: Sync links to KV + D1
         run: pnpm --filter @gitly/scripts sync-links
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
 
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary

Fixes #42 — Click tracking was not storing data in D1.

## Root Cause

The `sync-links.ts` script only synced links to **KV** (for fast redirects) but never populated the **D1 `links` table** required for analytics.

This caused:
- `UPDATE links SET clicks = clicks + 1` to match 0 rows
- Analytics API JOIN queries to return no results

## Changes

### `scripts/sync-links.ts`
- Added `syncToD1()` function that upserts links via D1 HTTP API
- Updated `syncToKV()` to store full `LinkData` object instead of raw URL
- Updated docs and env var requirements

### `.github/workflows/deploy.yml`
- Added `D1_DATABASE_ID` secret to the sync step

## Deployment Checklist

- [ ] Add `D1_DATABASE_ID` to GitHub repo secrets
  - Value: `1e16ea5f-2890-4d1b-99a3-31f50925fe31` (from wrangler.toml)
- [ ] Merge this PR
- [ ] Verify clicks are being tracked after next deploy

## Notes

- Existing clicks in the `clicks` table will retroactively appear in analytics once the `links` table is populated
- The KV format change is backwards-compatible (worker already handles both raw URL and JSON object formats)