### PR TITLE
chore: update Wrangler to v4

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,9 +13,9 @@
     "qrcode": "^1.5.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240208.0",
+    "@cloudflare/workers-types": "^4.20250204.0",
     "@types/qrcode": "^1.5.5",
     "typescript": "^5.3.0",
-    "wrangler": "^3.28.0"
+    "wrangler": "^4.0.0"
   }
 }

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -1,6 +1,6 @@
 name = "gitly-sh"
 main = "src/index.ts"
-compatibility_date = "2024-02-01"
+compatibility_date = "2025-02-01"
 
 # Production route
 routes = [


### PR DESCRIPTION
## Summary

Updates Wrangler from v3.28.0 to v4.0.0 as approved in #44.

## Changes

- `wrangler`: ^3.28.0 → ^4.0.0
- `@cloudflare/workers-types`: ^4.20240208.0 → ^4.20250204.0
- `compatibility_date`: 2024-02-01 → 2025-02-01

## Migration Review

Per the [Wrangler v4 migration guide](https://developers.cloudflare.com/workers/wrangler/migration/update-v3-to-v4/):

- ✅ **Node.js v16 EOL** - We use Node.js 20, not affected
- ✅ **esbuild upgrade** - No dynamic wildcard imports in use
- ✅ **Commands default to local** - Scripts use direct Cloudflare API calls, not wrangler CLI
- ✅ **Deprecated features removed** - No usage of `legacy_assets`, `node_compat`, `getBindingsProxy`, or `usage_model`
- ✅ **GitHub Actions** - `cloudflare/wrangler-action@v3` is compatible with wrangler v4

No code changes required.

Closes #44