### PR TITLE
docs: Add guide for adding new links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,51 @@ A URL shortener for developers.
 
 A fast, API-first URL shortener built for the development workflow. Think bit.ly, but for git people.
 
+## Adding Your Links
+
+Want to add short links? It's as simple as opening a PR.
+
+### Quick Start
+
+1. **Fork this repository**
+
+2. **Create your links file** at `links/<your-github-username>/links.csv`:
+   ```csv
+   slug,url
+   gh,https://github.com/yourusername
+   blog,https://yourblog.com
+   ```
+
+3. **Open a pull request** to the `main` branch
+
+4. **Automated validation** will check your links and ensure you're only modifying your own folder
+
+5. **Once merged**, your links will be live at `gitly.sh/<slug>`
+
+### CSV Format
+
+Your `links.csv` file should have two columns:
+- **slug** — The short path (e.g., `gh` becomes `gitly.sh/gh`)
+- **url** — The destination URL
+
+Example:
+```csv
+slug,url
+gh,https://github.com/octocat
+twitter,https://twitter.com/octocat
+portfolio,https://octocat.io
+```
+
+### Rules
+
+- You can only edit files in `links/<your-github-username>/`
+- Slugs must be unique across your links
+- URLs must be valid and accessible
+
+### Need a different username?
+
+If you want to claim a folder that doesn't match your GitHub username, [open an issue](https://github.com/andrewmurphyio/gitly.sh/issues/new) to request it.
+
 ## Development
 
 This project is being built collaboratively between a human and AI agents. See:


### PR DESCRIPTION
Closes #47

## Summary

Adds documentation to the README explaining how users can add their own short links to gitly.sh.

## Changes

- Added "Adding Your Links" section with:
  - Step-by-step quick start guide
  - CSV format documentation with examples
  - Folder ownership rules
  - Instructions for requesting non-matching usernames

## Preview

The new section explains the full workflow:
1. Fork the repo
2. Create `links/<username>/links.csv`
3. Open a PR
4. Automated validation runs
5. Links go live on merge