### PR TITLE
fix: update sync-analytics workflow to use TypeScript script

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -24,12 +24,21 @@ jobs:
         with:
           node-version: '20'
       
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      
       - name: Fetch and sync analytics
+        working-directory: scripts
         env:
           ANALYTICS_API_URL: ${{ secrets.ANALYTICS_API_URL }}
           ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
         run: |
-          node scripts/sync-analytics.mjs
+          pnpm sync-analytics
       
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
## Summary

The `sync-analytics` script was converted from `.mjs` to `.ts` (TypeScript) but the workflow still referenced the old `.mjs` path, causing CI failures.

## Changes

- Add pnpm setup step
- Install dependencies (required for `tsx` to run TypeScript)
- Run the npm script `pnpm sync-analytics` instead of directly invoking `node scripts/sync-analytics.mjs`

## Root Cause

Commit e00c495 converted the script to TypeScript but didn't update the workflow file.

Fixes #49