### PR TITLE
docs: add analytics section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,62 @@ portfolio,https://octocat.io
 
 If you want to claim a folder that doesn't match your GitHub username, [open an issue](https://github.com/andrewmurphyio/gitly.sh/issues/new) to request it.
 
+## Analytics
+
+Every click on your short links is tracked automatically. Analytics data is exported to your folder as CSV files — no dashboard login required.
+
+### What We Track
+
+| Data Point | Description |
+|------------|-------------|
+| Click timestamp | When the link was clicked (UTC) |
+| Referrer | Where the click came from |
+| Country & City | Geographic location (via Cloudflare) |
+| Device type | Mobile, Desktop, or Tablet |
+| Browser | Chrome, Safari, Firefox, etc. |
+| OS | iOS, Android, Windows, macOS, etc. |
+| Unique visitors | Hashed daily (privacy-preserving) |
+
+### How It Works
+
+1. **Click happens** → Analytics recorded instantly at the edge
+2. **Hourly export** → GitHub Actions syncs new clicks to your folder
+3. **CSV files** → Raw data appears in `links/<username>/analytics/YYYY/MM/DD.csv`
+
+### File Structure
+
+```
+links/<your-username>/
+├── links.csv
+└── analytics/
+    └── 2026/
+        └── 02/
+            ├── 14.csv
+            └── 15.csv
+```
+
+### CSV Format
+
+```csv
+clicked_at,slug,referrer,country,city,device_type,browser,os
+2026-02-15T03:22:41Z,gh,https://twitter.com,US,San Francisco,mobile,Safari,iOS
+2026-02-15T10:15:33Z,blog,https://google.com,GB,London,desktop,Chrome,Windows
+```
+
+### Privacy
+
+- **No cookies** — We don't use tracking cookies
+- **No fingerprinting** — Just basic request headers
+- **IP hashing** — IPs are hashed daily for unique visitor counts, then discarded
+- **Your data** — Analytics live in your folder, version-controlled and portable
+
+### Why GitHub-Native?
+
+Your analytics are just files in your folder:
+- **Diffable** — See changes over time in git history
+- **Portable** — Download, analyze, or migrate anytime
+- **Programmable** — Build your own charts, alerts, or dashboards on top
+
 ## Development
 
 This project is being built collaboratively between a human and AI agents. See:


### PR DESCRIPTION
## Summary

Adds documentation explaining how analytics work in gitly.sh.

## What's Included

- **What we track**: Click timestamp, referrer, geo (country/city), device type, browser, OS, unique visitors
- **How it works**: Edge capture → hourly GitHub Actions export → CSV files in user folders
- **File structure**: `links/<username>/analytics/YYYY/MM/DD.csv`
- **Privacy**: No cookies, no fingerprinting, daily IP hashing, user-owned data
- **Why GitHub-native**: Diffable, portable, programmable

## References

- Based on [ADR-007](./docs/decisions/007-analytics-scope.md) and [ADR-008](./docs/decisions/008-analytics-export.md)
- Accurate to current Worker implementation

Closes #53