### PR TITLE
chore: disable sync-analytics cron until API ready

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -1,8 +1,9 @@
 name: Sync Analytics
 
 on:
-  schedule:
-    - cron: '0 * * * *'
+  # Schedule disabled until analytics API is implemented (see #56)
+  # schedule:
+  #   - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Commented out the hourly schedule trigger since the analytics API returns 404 (not implemented yet). Manual `workflow_dispatch` trigger remains available.

Fixes #56