### PR TITLE
feat: add total.csv for all-time click aggregation

### DIFF
--- a/docs/decisions/008-analytics-export.md
+++ b/docs/decisions/008-analytics-export.md
@@ -43,9 +43,26 @@ Fine-grained GitHub PAT with:
 - Fetches clicks from the last hour (with overlap buffer to avoid gaps)
 - Appends to today's CSV (creates file if missing)
 
+### Totals File
+
+In addition to daily CSVs, a `total.csv` file aggregates all-time click counts per slug:
+
+```
+links/<username>/analytics/total.csv
+```
+
+Format:
+```csv
+slug,clicks
+abc123,1542
+xyz789,891
+```
+
+Two columns, sorted by clicks descending. Regenerated from daily CSVs on each sync run (overwrites previous).
+
 ### Scope
 
-Raw click data only. No aggregation or summary files for MVP.
+Raw click data in daily CSVs, plus aggregated totals. No time-period breakdowns for MVP.
 
 ## Consequences
 
@@ -64,7 +81,7 @@ Raw click data only. No aggregation or summary files for MVP.
 
 ### Deferred
 
-- `summary.csv` with daily/weekly aggregates
+- Time-period breakdowns (daily/weekly/monthly summaries)
 - Webhook-based real-time sync
 - User-configurable export frequency
 - Compression of old months (`.csv.gz`)


### PR DESCRIPTION
Implements total.csv for gitly.sh analytics.

## Changes
- Generate `total.csv` per user at `links/<username>/analytics/total.csv`
- Format: `slug,clicks` - two columns, sorted by clicks descending
- Regenerated from daily CSVs on each hourly sync run (overwrites previous)
- Updated ADR-008 to document the totals file format

## Design
Simple all-time aggregation with no time-period breakdowns. The file is regenerated fresh each run by scanning all daily CSVs, ensuring consistency.

Closes #58