### PR TITLE
feat(worker): enable worker logs for observability

### DIFF
--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -21,3 +21,16 @@ database_id = "1e16ea5f-2890-4d1b-99a3-31f50925fe31"
 
 # Environment variables (set via wrangler secret)
 # ANALYTICS_API_KEY - API key for analytics export endpoint
+
+# Observability configuration
+# https://developers.cloudflare.com/workers/observability/
+[observability]
+enabled = false
+
+[observability.logs]
+enabled = true
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false


### PR DESCRIPTION
## Summary
Adds observability configuration to `wrangler.toml` to enable persistent worker logs for debugging.

## Changes
- `observability.enabled: false` (main toggle off, but logs explicitly enabled)
- `observability.logs.enabled: true`
- `observability.logs.persist: true`
- `observability.logs.invocation_logs: true`
- `observability.traces.enabled: false`

This allows viewing worker invocation logs in the Cloudflare dashboard without enabling full tracing.

## References
- [Cloudflare Workers Observability Docs](https://developers.cloudflare.com/workers/observability/)

Closes #64