### PR TITLE
Add debug step to sync-analytics workflow

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
+      - name: Debug API URL
+        env:
+          ANALYTICS_API_URL: ${{ secrets.ANALYTICS_API_URL }}
+        run: |
+          echo "URL length: ${#ANALYTICS_API_URL}"
+          echo "URL starts with: ${ANALYTICS_API_URL:0:8}"
+          echo "Testing endpoint..."
+          curl -s -w "\nHTTP: %{http_code}" "${ANALYTICS_API_URL}/api/analytics" || echo 'curl failed'
+      
       - name: Fetch and sync analytics
         working-directory: scripts
         env:


### PR DESCRIPTION
Adds a debug step to investigate the 404 error in #62.

The debug step will:
1. Print the URL length (to detect hidden characters)
2. Print the first 8 chars (to verify format without leaking full URL)
3. Test the endpoint directly with curl and show the HTTP status

This will help us determine if:
- The `ANALYTICS_API_URL` secret has a typo or invisible chars
- The endpoint is actually reachable from GHA runners
- There was a timing issue with deploy propagation

Ref: #62