### PR TITLE
fix: resolve paths relative to repo root in sync-analytics

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -39,12 +39,10 @@ jobs:
           curl -s -w "\nHTTP: %{http_code}" "${ANALYTICS_API_URL}/api/analytics" || echo 'curl failed'
       
       - name: Fetch and sync analytics
-        working-directory: scripts
         env:
           ANALYTICS_API_URL: ${{ secrets.ANALYTICS_API_URL }}
           ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
-        run: |
-          pnpm sync-analytics
+        run: pnpm --filter @gitly/scripts sync-analytics
       
       - name: Commit and push changes
         run: |

--- a/scripts/sync-analytics.ts
+++ b/scripts/sync-analytics.ts
@@ -15,6 +15,13 @@
 
 import { writeFile, mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve repo root relative to this script (scripts/ → repo root)
+// This ensures paths work regardless of CWD
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, "..");
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -157,7 +164,7 @@ async function main(): Promise<void> {
   const usersWithNewData = new Set<string>();
 
   for (const [, { user, year, month, day, clicks }] of byUserAndDate) {
-    const filePath = join("links", user, "analytics", year, month, `${day}.csv`);
+    const filePath = join(REPO_ROOT, "links", user, "analytics", year, month, `${day}.csv`);
     const dirPath = dirname(filePath);
 
     // Ensure directory exists
@@ -234,7 +241,7 @@ async function main(): Promise<void> {
  * Format: slug,clicks (sorted by clicks descending)
  */
 async function generateTotalCsv(user: string): Promise<void> {
-  const analyticsDir = join("links", user, "analytics");
+  const analyticsDir = join(REPO_ROOT, "links", user, "analytics");
   const totalPath = join(analyticsDir, "total.csv");
 
   // Aggregate clicks by slug


### PR DESCRIPTION
Fixes #67

## Problem
The sync-analytics script was writing CSV files to paths relative to CWD. The workflow ran from the `scripts/` directory, so files ended up at `scripts/links/...` instead of `links/...`. Git then checked for changes in `links/*/analytics/` and found nothing.

## Solution
1. **Script fix (Option A):** Added `REPO_ROOT` constant calculated from `__dirname` using ESM patterns. All file paths are now prefixed with `REPO_ROOT`.
2. **Workflow cleanup:** Removed `working-directory: scripts` and use `pnpm --filter @gitly/scripts` instead.

The script now works correctly regardless of where it's invoked from.

## Changes
- `scripts/sync-analytics.ts`: Add `fileURLToPath` import, calculate `REPO_ROOT`, prefix paths
- `.github/workflows/sync-analytics.yml`: Remove `working-directory`, use `--filter`