### PR TITLE
fix: stage analytics files before checking for changes

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -49,11 +49,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          if git diff --quiet && git diff --staged --quiet; then
-            echo "No analytics changes to commit"
-            exit 0
-          fi
-          
           git add links/*/analytics/
           
           if git diff --staged --quiet; then


### PR DESCRIPTION
## Summary

Fixes the analytics sync workflow that was failing to detect new analytics files.

## Problem

The workflow checked `git diff --quiet` **before** staging files. Since new analytics files are untracked, `git diff` would not see them, causing the workflow to exit early with "No analytics changes to commit" even when there were new files to commit.

## Solution

Stage files first with `git add`, then check `git diff --staged --quiet` to correctly detect both new and modified analytics files.

Fixes #67