### PR TITLE
fix(security): truncate User-Agent to prevent storage abuse

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -27,6 +27,9 @@ interface ClickRow {
   created_by: string // Joined from links table
 }
 
+// Security: Limit stored User-Agent length to prevent storage abuse
+const MAX_UA_LENGTH = 512
+
 const app = new Hono<{ Bindings: Bindings }>()
 
 // Security headers middleware
@@ -129,8 +132,9 @@ async function recordClick(c: any, slug: string): Promise<void> {
     const now = Math.floor(Date.now() / 1000)
     const today = new Date().toISOString().split('T')[0] // YYYY-MM-DD for hash salt
     
-    // Extract data from request
-    const ua = c.req.header('User-Agent') || null
+    // Extract data from request (truncate UA to prevent storage abuse)
+    const rawUa = c.req.header('User-Agent')
+    const ua = rawUa ? rawUa.slice(0, MAX_UA_LENGTH) : null
     const referrer = c.req.header('Referer') || null
     const cf = (c.req.raw as any).cf || {}
     


### PR DESCRIPTION
## Summary

Truncates User-Agent strings to 512 characters before storing in D1, preventing storage abuse via arbitrarily long UA strings.

## Changes

- Added `MAX_UA_LENGTH = 512` constant
- Modified `recordClick()` to truncate UA before storage
- UA is truncated before being passed to `parseUserAgent()` as well

## Testing

Manual review of the change. The truncation is applied early, so both the parsed UA data and the raw stored UA are bounded.

## Notes

512 chars is plenty for legitimate User-Agents (most are under 256). This prevents abuse while preserving all useful data.

Fixes #78