### PR TITLE
feat: Add rate limiting to protect against abuse

### DIFF
--- a/apps/worker/src/rate-limit.ts
+++ b/apps/worker/src/rate-limit.ts
@@ -1,0 +1,95 @@
+import { Context, MiddlewareHandler } from 'hono'
+
+/**
+ * Cloudflare Workers Rate Limiting API binding
+ * @see https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+ */
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>
+}
+
+interface RateLimitOptions {
+  /** Function to extract the rate limit key from the request */
+  keyFunc: (c: Context) => string | Promise<string>
+  /** Optional custom error response */
+  errorResponse?: (c: Context) => Response
+}
+
+/**
+ * Creates a rate limiting middleware using Cloudflare's native Rate Limiting API.
+ * 
+ * @param binding - The rate limiter binding from env (e.g., env.QR_RATE_LIMITER)
+ * @param options - Configuration options including key extraction function
+ * @returns Hono middleware handler
+ * 
+ * @example
+ * ```ts
+ * app.use('/api/*', rateLimitMiddleware(
+ *   (c) => c.env.API_RATE_LIMITER,
+ *   { keyFunc: (c) => c.req.header('Authorization') || getClientIP(c) }
+ * ))
+ * ```
+ */
+export function createRateLimiter(
+  getBinding: (c: Context) => RateLimitBinding,
+  options: RateLimitOptions
+): MiddlewareHandler {
+  return async (c, next) => {
+    const binding = getBinding(c)
+    
+    // If binding is not available (local dev without rate limiting), skip
+    if (!binding?.limit) {
+      return next()
+    }
+
+    const key = await options.keyFunc(c)
+    
+    // Empty key bypasses rate limiting (useful for trusted sources)
+    if (!key) {
+      return next()
+    }
+
+    const { success } = await binding.limit({ key })
+
+    if (!success) {
+      if (options.errorResponse) {
+        return options.errorResponse(c)
+      }
+      
+      return c.json(
+        { 
+          error: 'Too Many Requests',
+          message: 'Rate limit exceeded. Please slow down.',
+          retryAfter: 10 // Hint for clients
+        },
+        429,
+        {
+          'Retry-After': '10',
+          'X-RateLimit-Limit': 'See rate limit documentation'
+        }
+      )
+    }
+
+    return next()
+  }
+}
+
+/**
+ * Extract client IP from Cloudflare headers.
+ * Falls back to X-Forwarded-For for non-Cloudflare requests (local dev).
+ */
+export function getClientIP(c: Context): string {
+  return (
+    c.req.header('CF-Connecting-IP') ||
+    c.req.header('X-Forwarded-For')?.split(',')[0]?.trim() ||
+    'unknown'
+  )
+}
+
+/**
+ * Generate a composite key for per-resource rate limiting.
+ * Combines client IP with a resource identifier (e.g., slug).
+ */
+export function compositeKey(ip: string, resource: string): string {
+  return `${ip}:${resource}`
+}

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -22,6 +22,30 @@ database_id = "1e16ea5f-2890-4d1b-99a3-31f50925fe31"
 # Environment variables (set via wrangler secret)
 # ANALYTICS_API_KEY - API key for analytics export endpoint
 
+# Rate limiting bindings (Cloudflare Workers Rate Limiting API)
+# See: https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+
+# QR endpoint - strict limit (CPU-expensive with logo processing)
+# 10 requests per 10 seconds per key
+[[ratelimits]]
+name = "QR_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 10, period = 10 }
+
+# Analytics API - moderate limit (authenticated but could be abused)
+# 30 requests per 60 seconds per key
+[[ratelimits]]
+name = "ANALYTICS_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 30, period = 60 }
+
+# Redirect endpoint - lenient limit (normal traffic, prevent click inflation)
+# 60 requests per 10 seconds per key
+[[ratelimits]]
+name = "REDIRECT_RATE_LIMITER"
+namespace_id = "1003"
+simple = { limit = 60, period = 10 }
+
 # Observability configuration
 # https://developers.cloudflare.com/workers/observability/
 [observability]


### PR DESCRIPTION
## Summary

Implements rate limiting using Cloudflare Workers native Rate Limiting API to address the security concerns in #77.

## Changes

### New Files
- `apps/worker/src/rate-limit.ts` - Reusable rate limiting middleware for Hono

### Modified Files
- `apps/worker/wrangler.toml` - Added three rate limit bindings
- `apps/worker/src/index.ts` - Applied rate limiting to all vulnerable endpoints

## Rate Limit Configuration

| Endpoint | Limit | Period | Key | Rationale |
|----------|-------|--------|-----|----------|
| `/:slug/qr` | 10 | 10s | IP + slug | CPU-expensive WASM logo processing |
| `/api/analytics` | 30 | 60s | API key | Authenticated but could extract data |
| `/:slug` | 60 | 10s | IP + slug | Prevent automated click inflation |

## Implementation Details

✅ **Option A from issue** - Uses Cloudflare's native Rate Limiting binding
- Zero added latency (counters cached locally)
- Eventually consistent (designed for rate limiting, not accounting)
- Gracefully degrades in local dev (binding check)

### Key Strategy

Keys combine client IP with resource identifier (slug) to enable:
- Per-link rate limiting (can't DoS all QR codes by hitting one)
- Fair distribution across users
- Prevention of single-IP click inflation on specific links

### Error Responses

- **QR/Analytics**: JSON with `retryAfter` hint
- **Redirect**: Human-friendly HTML (user-facing)

## Testing

```bash
# Build passes
cd apps/worker && npm run build

# Bindings verified
env.QR_RATE_LIMITER (10 requests/10s)        Rate Limit
env.ANALYTICS_RATE_LIMITER (30 requests/60s) Rate Limit
env.REDIRECT_RATE_LIMITER (60 requests/10s)  Rate Limit
```

## Not Included

- IP-only rate limiting on root `/` (low risk, can add if needed)
- Global per-IP limits (kept per-resource for fairness)

Closes #77