### PR TITLE
fix(security): add secret pepper to visitor IP hash

### DIFF
--- a/apps/worker/src/ua-parser.ts
+++ b/apps/worker/src/ua-parser.ts
@@ -92,10 +92,18 @@ function detectOS(ua: string): string {
 
 /**
  * Hash an IP address for unique visitor tracking.
- * Uses SHA-256 with a daily salt to prevent long-term tracking.
+ * Uses SHA-256 with a secret pepper and daily salt to prevent:
+ * - Long-term tracking (daily rotation)
+ * - Pre-computation attacks (secret pepper)
+ * 
+ * @param ip - The visitor's IP address
+ * @param date - Date string for daily rotation (YYYY-MM-DD)
+ * @param secret - Secret pepper from environment variable (HASH_SECRET)
  */
-export async function hashIP(ip: string, date: string): Promise<string> {
-  const salt = `gitly.sh:${date}` // Daily rotation
+export async function hashIP(ip: string, date: string, secret: string): Promise<string> {
+  // Salt includes secret pepper to prevent pre-computation attacks
+  // Even if attacker knows the IP, they can't compute expected hashes without the secret
+  const salt = `gitly.sh:${secret}:${date}`
   const data = new TextEncoder().encode(`${salt}:${ip}`)
   const hash = await crypto.subtle.digest('SHA-256', data)
   const hashArray = Array.from(new Uint8Array(hash))

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -21,6 +21,8 @@ database_id = "1e16ea5f-2890-4d1b-99a3-31f50925fe31"
 
 # Environment variables (set via wrangler secret)
 # ANALYTICS_API_KEY - API key for analytics export endpoint
+# HASH_SECRET - Secret pepper for visitor IP hashing (prevents pre-computation attacks)
+#               Generate with: openssl rand -hex 32
 
 # Rate limiting bindings (Cloudflare Workers Rate Limiting API)
 # See: https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/


### PR DESCRIPTION
## Summary

Addresses #101 - adds a secret pepper to the visitor IP hash to prevent pre-computation attacks.

## Changes

- Updated `hashIP()` function to accept a `secret` parameter
- Salt now includes the secret pepper: `gitly.sh:${secret}:${date}`
- Added `HASH_SECRET` to worker Bindings type
- Added documentation in `wrangler.toml` for setting the secret

## Security Impact

This prevents an attacker who knows a target's IP from:
- Pre-computing expected `visitor_hash` values for any day
- Correlating visits across different slugs
- Identifying if a specific person clicked a link

## Implementation Notes

I chose the simple pepper approach over HMAC because:
- Equivalent security for this use case (preventing pre-computation)
- Simpler implementation without SubtleCrypto `importKey` complexity
- Consistent with the existing SHA-256 digest approach

## Deploy Checklist

- [ ] Set the secret before deploying:
  ```bash
  wrangler secret put HASH_SECRET
  # Paste output of: openssl rand -hex 32
  ```

**Note:** Existing `visitor_hash` values will no longer match after deploying (expected - the salt changed). This has no functional impact since hashes are only used for daily unique visitor counting.

Closes #101