### PR TITLE
feat: add security headers (HSTS, CSP, Referrer-Policy, Permissions-Policy)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -55,8 +55,17 @@ const app = new Hono<{ Bindings: Bindings }>()
 // Security headers middleware
 app.use('*', async (c, next) => {
   await next()
+  // Existing headers
   c.header('X-Content-Type-Options', 'nosniff')
   c.header('X-Frame-Options', 'DENY')
+  // HSTS - enforce HTTPS for 1 year including subdomains
+  c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  // CSP - restrictive policy (no external resources needed)
+  c.header('Content-Security-Policy', "default-src 'none'")
+  // Referrer policy - send origin for cross-origin, full URL for same-origin
+  c.header('Referrer-Policy', 'strict-origin-when-cross-origin')
+  // Permissions policy - disable sensitive browser features
+  c.header('Permissions-Policy', 'geolocation=(), camera=(), microphone=()')
 })
 
 // Health check (no rate limiting - used for monitoring)
@@ -187,7 +196,14 @@ app.get('/:slug',
             status: 429,
             headers: {
               'Content-Type': 'text/html',
-              'Retry-After': '10'
+              'Retry-After': '10',
+              // Security headers (duplicated from middleware since raw Response bypasses it)
+              'X-Content-Type-Options': 'nosniff',
+              'X-Frame-Options': 'DENY',
+              'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+              'Content-Security-Policy': "default-src 'none'",
+              'Referrer-Policy': 'strict-origin-when-cross-origin',
+              'Permissions-Policy': 'geolocation=(), camera=(), microphone=()'
             }
           }
         )


### PR DESCRIPTION
## Summary

Adds comprehensive security headers to all responses as requested in #102.

## Headers Added

| Header | Value | Purpose |
|--------|-------|--------|
| Strict-Transport-Security | max-age=31536000; includeSubDomains | Enforce HTTPS for 1 year |
| Content-Security-Policy | default-src 'none' | Restrictive CSP (service has no HTML with external resources) |
| Referrer-Policy | strict-origin-when-cross-origin | Control referrer leakage |
| Permissions-Policy | geolocation=(), camera=(), microphone=() | Disable sensitive features |

## Implementation Notes

- Headers added to the existing security headers middleware (applies to all responses)
- Also added headers to the rate-limit HTML response which bypasses Hono middleware by returning a raw `Response` object

## CSP Considerations

The `default-src 'none'` policy is appropriate for this service because:
- Root `/` returns JSON
- `/:slug` returns redirects
- `/api/analytics` returns JSON
- `/:slug/qr` returns images (SVG/PNG)
- Rate limit page is simple HTML with no scripts, styles, or images

Closes #102