### PR TITLE
feat(security): add missing security headers

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -55,8 +55,14 @@ const app = new Hono<{ Bindings: Bindings }>()
 // Security headers middleware
 app.use('*', async (c, next) => {
   await next()
+  // Existing security headers
   c.header('X-Content-Type-Options', 'nosniff')
   c.header('X-Frame-Options', 'DENY')
+  // Additional security headers (GitHub issue #102)
+  c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  c.header('Content-Security-Policy', "default-src 'none'; img-src data:; style-src 'unsafe-inline'")
+  c.header('Referrer-Policy', 'strict-origin-when-cross-origin')
+  c.header('Permissions-Policy', 'geolocation=(), camera=(), microphone=()')
 })
 
 // Health check (no rate limiting - used for monitoring)


### PR DESCRIPTION
## Summary
Adds missing security headers as requested in #102.

## Headers Added
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` - Enforces HTTPS
- `Content-Security-Policy: default-src 'none'; img-src data:; style-src 'unsafe-inline'` - Restrictive CSP suitable for redirect service
- `Referrer-Policy: strict-origin-when-cross-origin` - Controls referrer information
- `Permissions-Policy: geolocation=(), camera=(), microphone=()` - Disables sensitive APIs

## CSP Notes
The CSP is intentionally restrictive since gitly.sh primarily serves redirects and JSON. The policy allows:
- `img-src data:` - for QR code data URIs
- `style-src 'unsafe-inline'` - for the simple rate-limit HTML page

Closes #102