### PR TITLE
feat: allow 1-2 character slugs

### DIFF
--- a/docs/decisions/004-slug-generation.md
+++ b/docs/decisions/004-slug-generation.md
@@ -37,7 +37,7 @@ When a user creates a short link without specifying a custom slug, we need to ge
 | Length | 6 characters |
 | Alphabet | Base62 (a-zA-Z0-9) |
 | Collision handling | Retry up to 3 times |
-| Custom slugs | Allowed, 3-50 chars |
+| Custom slugs | Allowed, 1-50 chars (updated via #119) |
 | Custom validation | Alphanumeric + hyphens |
 
 ## Decision
@@ -45,5 +45,5 @@ When a user creates a short link without specifying a custom slug, we need to ge
 **Accepted: Option A/B — 6-char Base62 using nanoid**
 
 - Auto-generated slugs: 6 characters, Base62 alphabet
-- Custom slugs allowed: 3-50 characters, alphanumeric + hyphens
+- Custom slugs allowed: 1-50 characters, alphanumeric + hyphens (single-char must be alphanumeric only)
 - Collision handling: Retry generation up to 3 times before failing


### PR DESCRIPTION
Implements the slug validation changes from #119.

## Changes

- Updated `validateSlug()` in `scripts/sync-links.ts` to allow:
  - Single-character slugs (alphanumeric only)
  - 2+ character slugs with alphanumeric + hyphens (no leading/trailing hyphens)
- Updated ADR-004 to reflect the new 1-50 char limit
- Removed the unused `SLUG_REGEX` constant

## Validation Logic

```typescript
// Single char: must be alphanumeric
if (trimmed.length === 1) {
  if (!/^[a-zA-Z0-9]$/.test(trimmed)) {
    return "Single-char slug must be alphanumeric";
  }
  return null;
}

// 2+ chars: alphanumeric + hyphens, no leading/trailing hyphens
if (!/^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$/.test(trimmed)) {
  return "Invalid format: use alphanumeric + hyphens, no leading/trailing hyphens";
}
```

Closes #119