### PR TITLE
fix: add validation for KV placeholder replacement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,3 +45,8 @@ jobs:
           workingDirectory: apps/worker
           preCommands: |
             sed -i "s/\$KV_NAMESPACE_ID/${{ secrets.KV_NAMESPACE_ID }}/g" wrangler.toml
+            # Verify replacement worked
+            if grep -q '\$KV_NAMESPACE_ID' wrangler.toml; then
+              echo "ERROR: KV_NAMESPACE_ID placeholder was not replaced"
+              exit 1
+            fi


### PR DESCRIPTION
Adds validation after the sed command to ensure the KV_NAMESPACE_ID placeholder was actually replaced. If the secret is missing or the replacement fails, the workflow will now exit with a clear error message instead of deploying with an invalid wrangler.toml.

Closes #129