### PR TITLE
fix: address security review items #2, #4, #5

### DIFF
--- a/apps/worker/src/ua-parser.ts
+++ b/apps/worker/src/ua-parser.ts
@@ -90,6 +90,23 @@ function detectOS(ua: string): string {
   return 'Other'
 }
 
+// Minimum required length for HASH_SECRET (256 bits = 32 chars of entropy)
+const MIN_HASH_SECRET_LENGTH = 32
+
+/**
+ * Validate that HASH_SECRET exists and meets minimum security requirements.
+ * Returns an error message if invalid, or null if valid.
+ */
+export function validateHashSecret(secret: string | undefined): string | null {
+  if (!secret) {
+    return 'HASH_SECRET is not configured'
+  }
+  if (secret.length < MIN_HASH_SECRET_LENGTH) {
+    return `HASH_SECRET too weak: ${secret.length} chars (minimum ${MIN_HASH_SECRET_LENGTH})`
+  }
+  return null // Valid
+}
+
 /**
  * Hash an IP address for unique visitor tracking.
  * Uses HMAC-SHA256 with a secret key and daily salt to prevent:


### PR DESCRIPTION
## Summary

Fixes three items from the security review in #132.

### Issue 2 - QR Code Cache Key (`apps/worker/src/qr.ts`)
- Use Cache API with explicit cache key including all query params (size, format, logo, logo_size)
- Builds normalized cache key to ensure different parameter combinations are cached separately
- Previously: cache could serve wrong QR if query params differed

### Issue 4 - D1 Batch Inserts (`scripts/sync-links.ts`)
- Batch all INSERT statements into a single D1 API request
- D1 HTTP API supports array of `{sql, params}` objects
- Chunks into batches of 100 (API limit)
- **Before:** 100 links = 100 sequential HTTP requests
- **After:** 100 links = 1 API request

### Issue 5 - HASH_SECRET Validation (`apps/worker/src/ua-parser.ts`, `apps/worker/src/index.ts`)
- Add `validateHashSecret()` with minimum 32 character requirement
- Check in `recordClick()` before calling `hashIP()`
- If HASH_SECRET is missing or weak: log error and skip analytics (redirect still works)
- Prevents crash or weak hashing if env var misconfigured

## Testing
- [ ] QR codes with different params return different cached results
- [ ] D1 sync script works with batched inserts
- [ ] Redirect works even without HASH_SECRET (analytics skipped)

Closes #132