### PR TITLE
fix: collapse multi-line if/fi in deploy preCommands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,8 +45,4 @@ jobs:
           workingDirectory: apps/worker
           preCommands: |
             sed -i "s/\$KV_NAMESPACE_ID/${{ secrets.KV_NAMESPACE_ID }}/g" wrangler.toml
-            # Verify replacement worked
-            if grep -q '\$KV_NAMESPACE_ID' wrangler.toml; then
-              echo "ERROR: KV_NAMESPACE_ID placeholder was not replaced"
-              exit 1
-            fi
+            if grep -q '\$KV_NAMESPACE_ID' wrangler.toml; then echo "ERROR: KV_NAMESPACE_ID placeholder was not replaced"; exit 1; fi


### PR DESCRIPTION
## Problem

The deploy workflow fails with:
```
/bin/sh: 1: Syntax error: end of file unexpected (expecting "fi")
```

## Root Cause

`cloudflare/wrangler-action` executes each line of `preCommands` as a **separate shell command**. The multi-line `if/then/fi` construct was being split across lines, so each line ran independently—an `if` without its `fi` is a syntax error.

## Fix

Collapse the if statement to a single line:
```bash
if grep -q ... ; then echo ...; exit 1; fi
```

Fixes #137