### PR TITLE
chore: re-enable hourly sync analytics cron

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -1,9 +1,8 @@
 name: Sync Analytics
 
 on:
-  # Schedule disabled until analytics API is implemented (see #56)
-  # schedule:
-  #   - cron: '0 * * * *'
+  schedule:
+    - cron: '0 * * * *'  # Hourly
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Re-enables the hourly cron schedule for the sync-analytics workflow.

## Changes

- Uncommented the `schedule` trigger in `.github/workflows/sync-analytics.yml`
- Removed the "disabled until analytics API is implemented" comment (it is now implemented!)

## Why

Per #140, the sync stopped running because the cron was intentionally disabled while waiting for the analytics API. The API is now working and manual runs succeed, so the schedule can be restored.

Closes #140