### PR TITLE
fix: add pull-requests write permission to post-merge workflow

### DIFF
--- a/.github/workflows/post-merge-notify.yml
+++ b/.github/workflows/post-merge-notify.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "links/**/*.csv"
 
+permissions:
+  pull-requests: write
+
 jobs:
   notify-new-links:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
The workflow uses `gh pr comment` which requires write access to pull requests. Without the explicit permissions block, the default GITHUB_TOKEN doesn't have sufficient permissions, causing:

```
GraphQL: Resource not accessible by integration (addComment)
```

## Changes

Added `permissions: pull-requests: write` to the workflow file.

Fixes #145