### PR TITLE
chore: force schedule re-registration

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 * * * *'  # Hourly
   workflow_dispatch:
 
+# Force schedule re-registration (2026-02-16)
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a comment to the workflow file to force GitHub to re-parse and re-register the schedule trigger.

Closes #143