### PR TITLE
feat: Add logo.png support for QR codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,48 @@ portfolio,https://octocat.io
 
 If you want to claim a folder that doesn't match your GitHub username, [open an issue](https://github.com/andrewmurphyio/gitly.sh/issues/new) to request it.
 
+## Custom Logo
+
+You can add a logo that appears in QR codes for your links.
+
+### Adding Your Logo
+
+1. Add a `logo.png` file to your folder: `links/<your-username>/logo.png`
+2. Requirements:
+   - **Format:** PNG only
+   - **Size:** Max 2MB
+   - **Recommended dimensions:** 200x200 to 500x500 pixels (square works best)
+
+### How It Works
+
+Once you add a `logo.png`, it will automatically be used when generating QR codes for your links:
+
+```
+https://gitly.sh/<your-slug>/qr
+```
+
+The logo appears centered in the QR code with a white background for readability.
+
+### Logo API
+
+You can also fetch your logo directly:
+
+```
+https://gitly.sh/api/logo/<your-username>
+```
+
+**Responses:**
+- `200` — Logo found, returns `image/png`
+- `204` — No logo exists for this user
+
+### Overriding the Logo
+
+You can override the default logo for any QR code using the `logo` query parameter:
+
+```
+https://gitly.sh/<slug>/qr?logo=https://example.com/my-other-logo.png
+```
+
 ## Analytics
 
 Every click on your short links is tracked automatically. Analytics data is exported to your folder as CSV files — no dashboard login required.

--- a/apps/worker/src/logo.ts
+++ b/apps/worker/src/logo.ts
@@ -1,0 +1,164 @@
+import { Context } from 'hono'
+
+/**
+ * Logo endpoint handler
+ * 
+ * Fetches a user's logo.png from their GitHub folder and serves it with caching.
+ * Logos are stored at: links/<username>/logo.png in the gitly.sh repo
+ * 
+ * Returns:
+ * - 200 with image/png on success
+ * - 204 No Content when logo doesn't exist
+ * - 400 for invalid username
+ * - 502 for upstream fetch failures
+ */
+
+// GitHub raw content URL for the gitly.sh repository
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/andrewmurphyio/gitly.sh/main/links'
+
+// Cache TTL: 1 hour (matches other assets)
+const CACHE_TTL_SECONDS = 3600
+
+// Maximum logo size: 2MB
+const MAX_LOGO_SIZE = 2 * 1024 * 1024
+
+// Fetch timeout: 10 seconds
+const LOGO_FETCH_TIMEOUT = 10000
+
+// Username validation: alphanumeric, hyphens, underscores (GitHub username rules)
+const USERNAME_PATTERN = /^[a-zA-Z0-9][-a-zA-Z0-9_]*$/
+
+/**
+ * Validate username format to prevent path traversal and injection
+ */
+function isValidUsername(username: string): boolean {
+  if (!username || username.length > 39) return false // GitHub max is 39 chars
+  if (username.startsWith('-') || username.endsWith('-')) return false
+  return USERNAME_PATTERN.test(username)
+}
+
+/**
+ * Build cache key for a user's logo
+ */
+function buildCacheKey(username: string): string {
+  return `https://gitly.sh/api/logo/${username}`
+}
+
+export async function handleLogo(c: Context) {
+  const username = c.req.param('username')
+  
+  // Validate username format
+  if (!isValidUsername(username)) {
+    return c.json({ error: 'Invalid username format' }, 400)
+  }
+
+  // Check cache first
+  const cache = caches.default
+  const cacheKey = buildCacheKey(username)
+  const cacheRequest = new Request(cacheKey)
+  
+  const cachedResponse = await cache.match(cacheRequest)
+  if (cachedResponse) {
+    return cachedResponse
+  }
+
+  // Fetch logo from GitHub
+  const logoUrl = `${GITHUB_RAW_BASE}/${username}/logo.png`
+  
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), LOGO_FETCH_TIMEOUT)
+  
+  let response: Response
+  try {
+    response = await fetch(logoUrl, { 
+      signal: controller.signal,
+      headers: {
+        // Include user-agent so GitHub doesn't reject the request
+        'User-Agent': 'gitly.sh-worker/1.0'
+      }
+    })
+  } catch (error) {
+    clearTimeout(timeout)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    
+    if (errorMessage.includes('abort')) {
+      return c.json({ error: 'Logo fetch timeout' }, 504)
+    }
+    
+    console.error(`Logo fetch failed for ${username}:`, error)
+    return c.json({ error: 'Failed to fetch logo' }, 502)
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  // Handle 404 - logo doesn't exist
+  if (response.status === 404) {
+    // Return 204 No Content (cacheable)
+    const noContentResponse = new Response(null, {
+      status: 204,
+      headers: {
+        'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`,
+      },
+    })
+    
+    // Cache the 204 response to avoid repeated GitHub requests
+    c.executionCtx.waitUntil(cache.put(cacheRequest, noContentResponse.clone()))
+    
+    return noContentResponse
+  }
+
+  // Handle other non-success status codes
+  if (!response.ok) {
+    console.error(`Logo fetch returned ${response.status} for ${username}`)
+    return c.json({ error: 'Failed to fetch logo' }, 502)
+  }
+
+  // Verify content-type is PNG
+  const contentType = response.headers.get('content-type')?.split(';')[0]?.trim()
+  if (contentType !== 'image/png') {
+    console.error(`Invalid logo content-type for ${username}: ${contentType}`)
+    return c.json({ error: 'Invalid logo format' }, 502)
+  }
+
+  // Check content-length if available
+  const contentLength = response.headers.get('content-length')
+  if (contentLength) {
+    const size = parseInt(contentLength, 10)
+    if (!isNaN(size) && size > MAX_LOGO_SIZE) {
+      return c.json({ error: 'Logo exceeds maximum size' }, 413)
+    }
+  }
+
+  // Read the body
+  const logoBuffer = await response.arrayBuffer()
+  
+  // Verify actual size
+  if (logoBuffer.byteLength > MAX_LOGO_SIZE) {
+    return c.json({ error: 'Logo exceeds maximum size' }, 413)
+  }
+
+  // Validate PNG magic bytes
+  const bytes = new Uint8Array(logoBuffer)
+  const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  const isPng = PNG_MAGIC.every((byte, i) => bytes[i] === byte)
+  
+  if (!isPng) {
+    console.error(`Logo for ${username} failed PNG magic byte validation`)
+    return c.json({ error: 'Invalid logo format' }, 502)
+  }
+
+  // Build successful response
+  const logoResponse = new Response(logoBuffer, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`,
+      'Content-Length': String(logoBuffer.byteLength),
+    },
+  })
+
+  // Cache the response
+  c.executionCtx.waitUntil(cache.put(cacheRequest, logoResponse.clone()))
+
+  return logoResponse
+}


### PR DESCRIPTION
## Summary

Implements logo.png support as requested in #146.

## Changes

### New `/api/logo/:username` endpoint
- Serves user logos from `links/<username>/logo.png` in the repo
- Fetches from `raw.githubusercontent.com` with caching
- Returns `200` with `image/png` when logo exists
- Returns `204 No Content` when logo doesn't exist (cacheable)
- Rate limited (reuses QR rate limiter)

### Auto-logo for QR codes
- QR codes now automatically use the user's logo.png when no explicit `logo` query param is provided
- Falls back gracefully if logo doesn't exist or fails to fetch

### Security
- PNG format validation (magic bytes)
- Max 2MB file size
- Username validation to prevent path traversal
- 10s fetch timeout

### Caching
- 1hr cache TTL (matches existing assets)
- Both logo responses and 204s are cached

## Documentation

Updated README with new "Custom Logo" section explaining:
- How to add a logo to your folder
- Logo requirements (PNG, max 2MB)
- Logo API endpoint
- How to override logos via query param

## Testing

- TypeScript compiles without errors
- Manual testing recommended with a deployed worker

Closes #146