### PR TITLE
fix: handle @username profile pages in /:slug route

### DIFF
--- a/apps/worker/src/dashboard.ts
+++ b/apps/worker/src/dashboard.ts
@@ -163,10 +163,18 @@ function truncateUrl(url: string, maxLength = 60): string {
 }
 
 export async function handleDashboard(c: Context): Promise<Response> {
-  const username = c.req.param('username')
+  // Support both /@:username route and fallback from /:slug route
+  // When called from /:slug, the slug includes the @ prefix which we strip
+  let username = c.req.param('username')
+  if (!username) {
+    const slug = c.req.param('slug')
+    if (slug?.startsWith('@')) {
+      username = slug.slice(1)
+    }
+  }
   
-  // Validate username format (alphanumeric, hyphens, underscores)
-  if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+  // Validate username exists and matches format (alphanumeric, hyphens, underscores)
+  if (!username || !/^[a-zA-Z0-9_-]+$/.test(username)) {
     return c.notFound()
   }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -264,6 +264,12 @@ app.get('/:slug',
   async (c) => {
   const slug = c.req.param('slug')
   
+  // Handle @username profile pages (Hono's router may match /:slug before /@:username)
+  // This ensures gitly.sh/@username correctly shows the user's dashboard
+  if (slug.startsWith('@')) {
+    return handleDashboard(c)
+  }
+  
   // Skip reserved slugs (case-insensitive, matches scripts/sync-links.ts validation)
   if (RESERVED_SLUGS.has(slug.toLowerCase())) {
     return c.notFound()


### PR DESCRIPTION
## Summary
Fixes #152 - Profile page at `/@username` was returning 404.

## Root Cause
Hono's router was matching `/:slug` before `/@:username` for paths like `/@andrewmurphyio`. The `@` character in the route pattern wasn't being treated as a literal prefix correctly by Hono's trie-based router.

## Fix
1. Add fallback handling in the `/:slug` handler to detect `@`-prefixed slugs and route them to `handleDashboard`
2. Update `handleDashboard` to extract username from either the `username` param (when matched via `/@:username`) or the `slug` param (when matched via `/:slug`)

## Testing
- `https://gitly.sh/@andrewmurphyio` should now show the user dashboard
- `https://gitly.sh/shortcode` continues to work for normal redirects
- `https://gitly.sh/health` returns `{"status":"ok"}`