### PR TITLE
fix: enable nodejs_compat for PNG QR code generation

### DIFF
--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -1,6 +1,7 @@
 name = "gitly-sh"
 main = "src/index.ts"
 compatibility_date = "2025-02-01"
+compatibility_flags = ["nodejs_compat"]
 
 # Production route
 routes = [


### PR DESCRIPTION
## Summary
Fixes #154 - QR code generation failed for PNG format.

## Root Cause
The `qrcode` library's `toBuffer()` method requires Node.js `Buffer` API which is not available in Cloudflare Workers by default. All PNG QR code requests were returning 500 errors.

## Investigation
- Confirmed all PNG requests fail (tested sizes: 64, 80, 100, 256)
- SVG format works fine (uses `toString()` which doesn't require Buffer)
- The `qrcode` package v1.5.3 needs Node.js Buffer API for PNG generation

## Fix
Add `compatibility_flags = ["nodejs_compat"]` to wrangler.toml to enable Node.js polyfills including Buffer.

## Testing
After deploying, these should all work:
- `https://gitly.sh/aam/qr?size=80` (PNG, the reported issue)
- `https://gitly.sh/aam/qr?size=256` (PNG, default size)
- `https://gitly.sh/aam/qr?format=svg` (SVG, already working)