### PR TITLE
fix: update CSP to allow dashboard styles and QR images

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -63,8 +63,10 @@ app.use('*', async (c, next) => {
   c.header('X-Frame-Options', 'DENY')
   // HSTS - enforce HTTPS for 1 year including subdomains
   c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
-  // CSP - restrictive policy (no external resources needed)
-  c.header('Content-Security-Policy', "default-src 'none'")
+  // CSP - restrictive policy allowing only what's needed:
+  // - style-src 'unsafe-inline': dashboard uses inline <style> tag
+  // - img-src 'self': QR code images served from same origin
+  c.header('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; img-src 'self'")
   // Referrer policy - send origin for cross-origin, full URL for same-origin
   c.header('Referrer-Policy', 'strict-origin-when-cross-origin')
   // Permissions policy - disable sensitive browser features


### PR DESCRIPTION
## Problem

The dashboard at `/@username` was not displaying correctly:
- CSS styles were not being applied (page appeared unstyled)
- QR code images were broken/not loading

## Root Cause

The Content-Security-Policy header was too restrictive:
```
Content-Security-Policy: default-src 'none'
```

This blocked:
- **Inline styles**: The dashboard uses a `<style>` tag for its CSS
- **Same-origin images**: QR codes are served from `/<slug>/qr`

## Solution

Updated the CSP to allow the necessary resources while maintaining security:
```
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src 'self'
```

- `style-src 'unsafe-inline'`: Allows the inline `<style>` tag in the dashboard
- `img-src 'self'`: Allows QR code images from the same origin

## Testing

- [x] Dashboard loads with proper styling
- [x] QR codes render correctly
- [x] CSP still blocks external resources

Fixes #160