### PR TITLE
fix(worker): use namespace import for qrcode library

### DIFF
--- a/apps/worker/src/qr.ts
+++ b/apps/worker/src/qr.ts
@@ -1,5 +1,5 @@
 import { Context } from 'hono'
-import QRCode from 'qrcode'
+import * as QRCode from 'qrcode'
 import { PhotonImage, SamplingFilter, resize, watermark } from '@cf-wasm/photon/workerd'
 import { validateUrlForFetch, safeFetch } from './url-validator'
 


### PR DESCRIPTION
## Problem

QR code generation was failing in production with error:
```
PNG generation error: import_qrcode.default.toBuffer is not a function
```

## Root Cause

The `qrcode` library is a CommonJS module. When using a default import (`import QRCode from 'qrcode'`) with esbuild bundling in Cloudflare Workers, the CJS module exports get wrapped in a way where `QRCode.toBuffer()` resolves to `import_qrcode.default.toBuffer` - which doesn't exist.

## Fix

Changed from default import to namespace import:
```diff
- import QRCode from 'qrcode'
+ import * as QRCode from 'qrcode'
```

This ensures the module exports are properly resolved at runtime regardless of how esbuild handles CJS-to-ESM interop.

Fixes #161