### PR TITLE
feat: QR size presets with image copy to clipboard

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -66,7 +66,13 @@ app.use('*', async (c, next) => {
   // CSP - restrictive policy allowing only what's needed:
   // - style-src 'unsafe-inline': dashboard uses inline <style> tag
   // - img-src 'self' data:: QR images from same origin, data URIs for logos embedded in SVG QR codes
-  c.header('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:")
+  // - script-src 'unsafe-inline': dashboard copy buttons need inline onclick handlers
+  const path = c.req.path
+  const isDashboard = path.startsWith('/@')
+  const csp = isDashboard
+    ? "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self' data:"
+    : "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:"
+  c.header('Content-Security-Policy', csp)
   // Referrer policy - send origin for cross-origin, full URL for same-origin
   c.header('Referrer-Policy', 'strict-origin-when-cross-origin')
   // Permissions policy - disable sensitive browser features


### PR DESCRIPTION
## Summary
Adds QR code size preset buttons to the dashboard with the ability to copy the actual QR image directly to clipboard.

## Changes
- Added QR size preset buttons (128px, 256px, 512px, 1024px) below each QR code
- Clicking a button copies the **actual PNG image** to clipboard (not just the URL)
- Users can paste directly into Slack, Docs, presentations, etc.
- Graceful fallback: if browser does not support clipboard image writing, copies URL instead
- Additional fallback: opens image in new tab if clipboard fails entirely
- Fixed CSP to allow inline script for copy functionality

## Technical Details
- Uses `navigator.clipboard.write()` with `ClipboardItem` for image data
- Fetches QR as blob and ensures PNG MIME type for compatibility
- Canvas conversion for non-PNG sources (future-proofing)

## Browser Support
- ✅ Chrome, Edge, Opera (full image clipboard support)
- ⚠️ Firefox, Safari (falls back to copying URL)

Closes #167